### PR TITLE
deps: use tar-archive instead of git for faster downloads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(FetchContent)
 add_subdirectory(src)
 
 add_subdirectory(ext/range-v3)
-FetchContent_GetProperties(range-v3)
+FetchContent_MakeAvailable(range-v3)
 
 add_library(range_v3 INTERFACE IMPORTED)
 set_target_properties(range_v3 PROPERTIES

--- a/ext/range-v3/CMakeLists.txt
+++ b/ext/range-v3/CMakeLists.txt
@@ -1,8 +1,7 @@
+ # <user>/<project>/archive/<tag>.tar.gz is faster than git (also works on Windows)
 FetchContent_Declare(
         range-v3
-        GIT_REPOSITORY https://github.com/ericniebler/range-v3.git
-        GIT_TAG 0.11.0
+        URL https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz
+        URL_HASH SHA256=376376615dbba43d3bef75aa590931431ecb49eb36d07bb726a19f680c75e20c
 )
-
-FetchContent_Populate(range-v3)
 


### PR DESCRIPTION
range-v3 is a big repo and I needed to wait too long until I could try out the C++20 awesomeness here